### PR TITLE
create symbolic instead of hard link

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -6,7 +6,7 @@ echo "mfp=\"$(pwd)/marks.txt\"" >> commands.sh
 
 echo "Creating link in /usr/bin"
 sudo rm -f /usr/bin/navtag
-sudo link navtag /usr/bin/navtag
+sudo ln -s navtag /usr/bin/navtag
 
 echo
 echo "------- IMPORTANT -------"


### PR DESCRIPTION
With this change the install script creates a symbolic link instead of hard linking to the binary.